### PR TITLE
Update memory configuration to correct RAM size and add detailed SRAM sections

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -5,5 +5,17 @@ MEMORY
   /* Application starts at ACTIVE region in Bank 1 */
   FLASH                             : ORIGIN = 0x08000000, LENGTH = 1024K  /* Bank 1 */
   DFU                               : ORIGIN = 0x08100000, LENGTH = 1024K  /* Bank 2 */
-  RAM                         (rwx) : ORIGIN = 0x24000000, LENGTH = 1024K  /* 1 MiB of RAM */
+  RAM                         (rwx) : ORIGIN = 0x24000000, LENGTH = 512K  /* 512 KiB of AXI ram */
+
+  /* DTCM is directly linked to the CPU and very fast but can't be used with DMA */
+  DTCM                        (rwx) : ORIGIN = 0x20000000, LENGTH = 128K  /* 128 KiB of DTCM */
+
+  /* SRAM is slower than AXI but can be used with DMA */
+  SRAM1                       (rwx) : ORIGIN = 0x30000000, LENGTH = 128K  /* 128 KiB of SRAM1 */
+  SRAM2                       (rwx) : ORIGIN = 0x30020000, LENGTH = 128K  /* 128 KiB of SRAM2 */
+  SRAM3                       (rwx) : ORIGIN = 0x30040000, LENGTH = 32K  /* 32 KiB of SRAM3 */
+  SRAM4                       (rwx) : ORIGIN = 0x38000000, LENGTH = 64K  /* 64 KiB of SRAM4 */
+
+  /* Backup SRAM is backed up by VBAT and can survive power cycles */
+  BACKUP_SRAM               (rwx) : ORIGIN = 0x38800000, LENGTH = 4K    /* 4 KiB of Backup SRAM */
 }


### PR DESCRIPTION
The code was not executing and crashing immediately as the memory layout was set incorrectly.
While the STM32H753VIT does have 1MB of RAM, it's not all in one spot and not all one type.

This change specifies each of the memory regions and how they work.

In a future PR, the RAM tag should be moved to the DTCM section, and a heap should be configured in AXI, or alternatively, static allocations for the DMA buffers should be made in AXI/SRAM.
The heap memory should then be used every time that a DMA buffer is required.

That will make the code faster as the DTCM will be used for all stack variables.