### PR TITLE
Add IMU driver and integrate with main application

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ignored = ["cortex-m", "cortex-m-rt"]
 [[bin]]
 name = "nusense-rs"
 path = "src/main.rs"
+harness = false
 
 [profile.dev]
 debug = true

--- a/src/apps/echo_app.rs
+++ b/src/apps/echo_app.rs
@@ -11,7 +11,8 @@
 //! - System status and diagnostics reporting
 //! - Configuration and calibration interfaces
 
-use crate::peripherals::{AcmConnection, Disconnected, MAX_PACKET_SIZE};
+use crate::peripherals::usb_system::MAX_PACKET_SIZE;
+use crate::peripherals::{AcmConnection, Disconnected};
 use defmt::{info, warn};
 use embassy_time::Timer;
 

--- a/src/drivers/imu/driver.rs
+++ b/src/drivers/imu/driver.rs
@@ -368,8 +368,10 @@ impl<'d> Icm20689<'d> {
 
         /// Number of bytes in a FIFO packet (6 accel + 2 temp + 6 gyro)
         const PACKET_SIZE: usize = 14;
+        /// Maximum number of packets to read from FIFO at once
+        const MAX_PACKETS: usize = 20;
         // Buffer sized for up to 20 packets to handle FIFO bursts
-        let mut fifo_buffer = [0u8; PACKET_SIZE * 20];
+        let mut fifo_buffer = [0u8; PACKET_SIZE * MAX_PACKETS];
 
         loop {
             // Wait for interrupt indicating new data

--- a/src/drivers/imu/driver.rs
+++ b/src/drivers/imu/driver.rs
@@ -40,6 +40,7 @@ enum Register {
 #[repr(u8)]
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "debug", derive(defmt::Format))]
+#[allow(dead_code)]
 pub enum AccelRange {
     G2 = 0b00 << 3,
     G4 = 0b01 << 3,
@@ -50,6 +51,7 @@ pub enum AccelRange {
 #[repr(u8)]
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "debug", derive(defmt::Format))]
+#[allow(dead_code)]
 pub enum GyroRange {
     Dps250 = 0b00 << 3,
     Dps500 = 0b01 << 3,

--- a/src/drivers/imu/driver.rs
+++ b/src/drivers/imu/driver.rs
@@ -397,8 +397,10 @@ impl<'d> Icm20689<'d> {
                                 }
                                 Err(e) => {
                                     defmt::warn!(
-                                        "IMU FIFO packet conversion error: expected 14 bytes, got {}, error: {:?}",
+                                        "IMU FIFO packet slice-to-array conversion failed: expected {} bytes, got {} bytes. Error type: {}. Error: {:?}",
+                                        PACKET_SIZE,
                                         packet.len(),
+                                        core::any::type_name::<_>(),
                                         e
                                     );
                                     continue;

--- a/src/drivers/imu/driver.rs
+++ b/src/drivers/imu/driver.rs
@@ -101,7 +101,7 @@ impl Default for ImuConfig {
 }
 
 /// IMU driver errors
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "debug", derive(defmt::Format))]
 pub enum ImuError {
     /// SPI communication error

--- a/src/drivers/imu/driver.rs
+++ b/src/drivers/imu/driver.rs
@@ -393,10 +393,11 @@ impl<'d> Icm20689<'d> {
                                     latest_temp = scaled.temperature;
                                     sample_count += 1;
                                 }
-                                Err(_) => {
+                                Err(e) => {
                                     defmt::warn!(
-                                        "IMU FIFO packet conversion error: expected 14 bytes, got {}",
-                                        packet.len()
+                                        "IMU FIFO packet conversion error: expected 14 bytes, got {}, error: {:?}",
+                                        packet.len(),
+                                        e
                                     );
                                     continue;
                                 }

--- a/src/drivers/imu/driver.rs
+++ b/src/drivers/imu/driver.rs
@@ -397,10 +397,9 @@ impl<'d> Icm20689<'d> {
                                 }
                                 Err(e) => {
                                     defmt::warn!(
-                                        "IMU FIFO packet slice-to-array conversion failed: expected {} bytes, got {} bytes. Error type: {}. Error: {:?}",
+                                        "IMU FIFO packet slice-to-array conversion failed: expected {} bytes, got {} bytes Error: {:?}",
                                         PACKET_SIZE,
                                         packet.len(),
-                                        core::any::type_name::<_>(),
                                         e
                                     );
                                     continue;

--- a/src/drivers/imu/driver.rs
+++ b/src/drivers/imu/driver.rs
@@ -185,7 +185,6 @@ impl<'d> Icm20689<'d> {
     /// Each 14-byte packet contains: [accel_x_h, accel_x_l, accel_y_h, accel_y_l,
     /// accel_z_h, accel_z_l, temp_h, temp_l, gyro_x_h, gyro_x_l, gyro_y_h, gyro_y_l, gyro_z_h, gyro_z_l]
     /// Returns scaled data in physical units (m/s² for accelerometer, rad/s for gyroscope, °C for temperature)
-    #[allow(clippy::cast_precision_loss)]
     pub fn parse_fifo_packet(&self, packet: &[u8; 14]) -> ImuData {
         // Parse raw values from FIFO packet
         let raw_accel = [
@@ -369,7 +368,7 @@ impl<'d> Icm20689<'d> {
 
         /// Number of bytes in a FIFO packet (6 accel + 2 temp + 6 gyro)
         const PACKET_SIZE: usize = 14;
-        /// Buffer sized for up to 20 packets to handle FIFO bursts
+        // Buffer sized for up to 20 packets to handle FIFO bursts
         let mut fifo_buffer = [0u8; PACKET_SIZE * 20];
 
         loop {

--- a/src/drivers/imu/mod.rs
+++ b/src/drivers/imu/mod.rs
@@ -1,0 +1,2 @@
+mod driver;
+pub use driver::Icm20689;

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,0 +1,7 @@
+//! Hardware drivers for the NUSense robotics platform.
+//!
+//! This module contains device drivers for various sensors and actuators
+//! used in the NUSense system.
+
+/// ICM-20689 IMU driver
+pub mod imu;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,15 @@
 
 // Application modules
 mod apps;
+mod drivers;
 mod peripherals;
 
 use apps::EchoApp;
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_futures::join::join;
-use peripherals::{init_system, AcmConnection, AcmState, UsbBuffers, UsbSystem};
+use embassy_futures::join::join3;
+use peripherals::usb_system::UsbBuffers;
+use peripherals::{init_system, AcmConnection, AcmState};
 
 // Import panic handler and defmt RTT for debugging
 #[cfg(not(feature = "debug"))]
@@ -31,15 +33,18 @@ async fn main(_spawner: Spawner) {
     info!("Starting NUSense firmware v{}", env!("CARGO_PKG_VERSION"));
 
     // Initialize STM32 peripherals with optimized clock configuration
-    let peripherals = init_system();
+    let mut peripherals = init_system();
 
     // Create memory buffers on the stack here
     // They won't go out of scope and mean there is no need for static or heap allocations
     let mut usb_buffers = UsbBuffers::new();
     let mut acm_state = AcmState::new();
 
-    // Initialize the USB system with the allocated buffers
-    let mut usb_system = UsbSystem::new(peripherals, &mut usb_buffers);
+    let spi = peripherals::spi::ImuSpi::new(claim_imu_spi!(peripherals));
+    let mut imu = drivers::imu::Icm20689::new(spi, claim_imu!(peripherals));
+
+    // Initialize the USB system
+    let mut usb_system = peripherals::usb_system::UsbSystem::new(claim_usb!(peripherals), &mut usb_buffers);
 
     // Create ACM connection using the USB builder and state
     let acm_connection = AcmConnection::new(usb_system.builder(), &mut acm_state);
@@ -47,14 +52,13 @@ async fn main(_spawner: Spawner) {
     // Initialize the echo application with the ACM connection
     let mut echo_app = EchoApp::new(acm_connection);
 
-    info!("System initialized, starting USB device and echo application...");
+    info!("System initialized, starting USB device, echo application, and IMU...");
 
-    // Run USB system and echo application concurrently until completion
-    // You must run the tasks in order here though so that the USB system is ready
-    // before the echo app starts using it.
+    // Run all tasks concurrently
     let usb_task = usb_system.run();
     let echo_task = echo_app.run();
+    let imu_task = imu.run();
 
-    // Both tasks run indefinitely, so this join never completes
-    join(usb_task, echo_task).await;
+    // All tasks run indefinitely, so this join never completes
+    join3(usb_task, echo_task, imu_task).await;
 }

--- a/src/peripherals/mod.rs
+++ b/src/peripherals/mod.rs
@@ -7,6 +7,8 @@
 
 /// CDC ACM (virtual serial port) implementation
 pub mod acm;
+/// SPI peripheral configuration
+pub mod spi;
 /// System initialization and clock configuration
 pub mod system;
 /// USB system abstraction
@@ -15,4 +17,3 @@ pub mod usb_system;
 // Re-export commonly used types for convenience
 pub use acm::{AcmConnection, AcmState, Disconnected};
 pub use system::init_system;
-pub use usb_system::{UsbBuffers, UsbSystem, MAX_PACKET_SIZE};

--- a/src/peripherals/spi.rs
+++ b/src/peripherals/spi.rs
@@ -101,6 +101,8 @@ impl<'d> ImuSpi<'d> {
     /// **Note:** This MSB read bit convention is device-specific.
     /// Consult your device's datasheet to determine the correct register read command format.
     pub async fn read_register(&mut self, reg: u8) -> Result<u8, embassy_stm32::spi::Error> {
+        /// Having the MSB of the register address set to 1 is the convention for reading from a register
+        const SPI_READ_BIT: u8 = 0x80;
         let tx_buf = [reg | SPI_READ_BIT, 0x00]; // Set read bit, dummy byte for response
         let mut rx_buf = [0u8; 2];
 
@@ -131,6 +133,8 @@ impl<'d> ImuSpi<'d> {
     /// 3. Send data value
     /// 4. Deassert chip select (high)
     pub async fn write_register(&mut self, reg: u8, value: u8) -> Result<(), embassy_stm32::spi::Error> {
+        /// Having the MSB of the register address set to 0 is the convention for writing to a register
+        const SPI_WRITE_MASK: u8 = 0x7F;
         let tx_buf = [reg & SPI_WRITE_MASK, value]; // Clear read bit
 
         self.cs.set_low();

--- a/src/peripherals/spi.rs
+++ b/src/peripherals/spi.rs
@@ -133,7 +133,7 @@ impl<'d> ImuSpi<'d> {
     /// 3. Send data value
     /// 4. Deassert chip select (high)
     pub async fn write_register(&mut self, reg: u8, value: u8) -> Result<(), embassy_stm32::spi::Error> {
-        /// Having the MSB of the register address set to 0 is the convention for writing to a register
+        // Having the MSB of the register address set to 0 is the convention for writing to a register
         const SPI_WRITE_MASK: u8 = 0x7F;
         let tx_buf = [reg & SPI_WRITE_MASK, value]; // Clear read bit
 

--- a/src/peripherals/spi.rs
+++ b/src/peripherals/spi.rs
@@ -131,7 +131,7 @@ impl<'d> ImuSpi<'d> {
     /// 3. Send data value
     /// 4. Deassert chip select (high)
     pub async fn write_register(&mut self, reg: u8, value: u8) -> Result<(), embassy_stm32::spi::Error> {
-        let tx_buf = [reg & 0x7F, value]; // Clear read bit
+        let tx_buf = [reg & SPI_WRITE_MASK, value]; // Clear read bit
 
         self.cs.set_low();
 

--- a/src/peripherals/spi.rs
+++ b/src/peripherals/spi.rs
@@ -101,7 +101,7 @@ impl<'d> ImuSpi<'d> {
     /// **Note:** This MSB read bit convention is device-specific.
     /// Consult your device's datasheet to determine the correct register read command format.
     pub async fn read_register(&mut self, reg: u8) -> Result<u8, embassy_stm32::spi::Error> {
-        let tx_buf = [reg | 0x80, 0x00]; // Set read bit, dummy byte for response
+        let tx_buf = [reg | SPI_READ_BIT, 0x00]; // Set read bit, dummy byte for response
         let mut rx_buf = [0u8; 2];
 
         self.cs.set_low();

--- a/src/peripherals/spi.rs
+++ b/src/peripherals/spi.rs
@@ -92,11 +92,14 @@ impl<'d> ImuSpi<'d> {
     /// * Register value on success
     /// * SPI error on failure
     ///
-    /// This function performs a generic SPI register read operation:
+    /// This function performs a register read operation for devices that use the MSB of the register address as a read bit flag:
     /// 1. Assert chip select (low)
     /// 2. Send register address with read bit set (MSB = 1)
     /// 3. Receive response data
     /// 4. Deassert chip select (high)
+    ///
+    /// **Note:** This MSB read bit convention is device-specific.
+    /// Consult your device's datasheet to determine the correct register read command format.
     pub async fn read_register(&mut self, reg: u8) -> Result<u8, embassy_stm32::spi::Error> {
         let tx_buf = [reg | 0x80, 0x00]; // Set read bit, dummy byte for response
         let mut rx_buf = [0u8; 2];

--- a/src/peripherals/spi.rs
+++ b/src/peripherals/spi.rs
@@ -101,7 +101,7 @@ impl<'d> ImuSpi<'d> {
     /// **Note:** This MSB read bit convention is device-specific.
     /// Consult your device's datasheet to determine the correct register read command format.
     pub async fn read_register(&mut self, reg: u8) -> Result<u8, embassy_stm32::spi::Error> {
-        /// Having the MSB of the register address set to 1 is the convention for reading from a register
+        // Having the MSB of the register address set to 1 is the convention for reading from a register
         const SPI_READ_BIT: u8 = 0x80;
         let tx_buf = [reg | SPI_READ_BIT, 0x00]; // Set read bit, dummy byte for response
         let mut rx_buf = [0u8; 2];

--- a/src/peripherals/spi.rs
+++ b/src/peripherals/spi.rs
@@ -1,0 +1,166 @@
+//! SPI peripheral configuration and management for NUSense platform.
+//!
+//! This module provides SPI configuration for various sensors including the ICM-20689 IMU.
+//! It handles DMA configuration for high-performance data transfer.
+
+use embassy_stm32::{
+    gpio::{Level, Output, Speed},
+    mode::Async,
+    peripherals::{DMA1_CH0, DMA1_CH1, PE11, PE12, PE13, PE14, SPI4},
+    spi::{Config as SpiConfig, Mode, Phase, Polarity, Spi},
+    time::Hertz,
+    Peri,
+};
+
+/// Macro to claim peripherals for ImuSpi
+#[macro_export]
+macro_rules! claim_imu_spi {
+    ($peripherals:expr) => {{
+        (
+            $peripherals.SPI4.reborrow(),
+            $peripherals.PE11.reborrow(),     // CS
+            $peripherals.PE12.reborrow(),     // SCK
+            $peripherals.PE13.reborrow(),     // MISO
+            $peripherals.PE14.reborrow(),     // MOSI
+            $peripherals.DMA1_CH0.reborrow(), // TX DMA
+            $peripherals.DMA1_CH1.reborrow(), // RX DMA
+        )
+    }};
+}
+
+/// SPI configuration for the ICM-20689 IMU
+///
+/// The ICM-20689 supports SPI mode 0 or 3. We use mode 3 (CPOL=1, CPHA=1) as per CubeMX config.
+/// SPI clock frequency is 8 MHz as per ICM-20689 datasheet maximum.
+/// Software chip select (PE11) is used for chip select control.
+pub struct ImuSpi<'d> {
+    /// SPI peripheral instance with DMA
+    pub spi: Spi<'d, Async>,
+    /// Chip select pin (software controlled)
+    pub cs: Output<'d>,
+}
+
+impl<'d> ImuSpi<'d> {
+    /// Create a new IMU SPI configuration with software chip select
+    ///
+    /// # Arguments
+    /// * `peripherals` - Tuple of (SPI4, PE11, PE12, PE13, PE14, DMA1_CH0, DMA1_CH1)
+    ///
+    /// # Returns
+    /// Configured SPI instance with software chip select control
+    pub fn new(
+        peripherals: (
+            Peri<'d, SPI4>,
+            Peri<'d, PE11>,     // CS
+            Peri<'d, PE12>,     // SCK
+            Peri<'d, PE13>,     // MISO
+            Peri<'d, PE14>,     // MOSI
+            Peri<'d, DMA1_CH0>, // TX DMA
+            Peri<'d, DMA1_CH1>, // RX DMA
+        ),
+    ) -> Self {
+        let (spi_peripheral, chip_select, sck, miso, mosi, dma_tx, dma_rx) = peripherals;
+
+        // Configure SPI for ICM-20689 to match CubeMX configuration
+        let mut config = SpiConfig::default();
+        config.mode = Mode {
+            polarity: Polarity::IdleHigh,
+            phase: Phase::CaptureOnSecondTransition,
+        };
+        config.frequency = Hertz(8_000_000);
+
+        let cs = Output::new(chip_select, Level::High, Speed::VeryHigh);
+
+        let spi = Spi::new(spi_peripheral, sck, mosi, miso, dma_tx, dma_rx, config);
+
+        Self { spi, cs }
+    }
+
+    /// Read a single register from an SPI device
+    ///
+    /// # Arguments
+    /// * `reg` - Register address to read from
+    ///
+    /// # Returns
+    /// * Register value on success
+    /// * SPI error on failure
+    ///
+    /// This function performs a generic SPI register read operation:
+    /// 1. Assert chip select (low)
+    /// 2. Send register address with read bit set (MSB = 1)
+    /// 3. Receive response data
+    /// 4. Deassert chip select (high)
+    pub async fn read_register(&mut self, reg: u8) -> Result<u8, embassy_stm32::spi::Error> {
+        let tx_buf = [reg | 0x80, 0x00]; // Set read bit, dummy byte for response
+        let mut rx_buf = [0u8; 2];
+
+        self.cs.set_low();
+
+        // Use SPI transfer to send command and receive response via DMA
+        let result = self.spi.transfer(&mut rx_buf, &tx_buf).await;
+
+        self.cs.set_high();
+
+        result?;
+        // Return the data byte (second byte of response)
+        Ok(rx_buf[1])
+    }
+
+    /// Write a single register to an SPI device
+    ///
+    /// # Arguments
+    /// * `reg` - Register address to write to
+    /// * `value` - Value to write to the register
+    ///
+    /// # Returns
+    /// * Success or SPI error
+    ///
+    /// This function performs a generic SPI register write operation:
+    /// 1. Assert chip select (low)
+    /// 2. Send register address with write bit clear (MSB = 0)
+    /// 3. Send data value
+    /// 4. Deassert chip select (high)
+    pub async fn write_register(&mut self, reg: u8, value: u8) -> Result<(), embassy_stm32::spi::Error> {
+        let tx_buf = [reg & 0x7F, value]; // Clear read bit
+
+        self.cs.set_low();
+
+        // Use SPI write to send command and data via DMA
+        let result = self.spi.write(&tx_buf).await;
+
+        self.cs.set_high();
+
+        result
+    }
+
+    /// Read data from a specific register using DMA
+    ///
+    /// # Arguments
+    /// * `reg` - Register address to read from
+    /// * `buffer` - Buffer to store the read data
+    ///
+    /// # Returns
+    /// * Success or SPI error
+    ///
+    /// This function performs a burst read operation:
+    /// 1. Assert chip select (low)
+    /// 2. Send register address with read bit set
+    /// 3. Read multiple bytes into buffer
+    /// 4. Deassert chip select (high)
+    pub async fn read_register_burst(&mut self, reg: u8, buffer: &mut [u8]) -> Result<(), embassy_stm32::spi::Error> {
+        self.cs.set_low();
+
+        // Send register address with read bit
+        let cmd = [reg | 0x80];
+
+        // First, send the command to set the register address
+        self.spi.write(&cmd).await?;
+
+        // Then read the data from the register
+        let result = self.spi.read(buffer).await;
+
+        self.cs.set_high();
+
+        result
+    }
+}

--- a/src/peripherals/usb_system.rs
+++ b/src/peripherals/usb_system.rs
@@ -17,18 +17,18 @@ macro_rules! claim_usb {
     ($peripherals:expr) => {{
         (
             $peripherals.USB_OTG_HS.reborrow(),
-            $peripherals.PA5.reborrow(),   // USB_OTG_HS_ULPI_CK
-            $peripherals.PC2.reborrow(),   // USB_OTG_HS_ULPI_DIR
-            $peripherals.PC3.reborrow(),   // USB_OTG_HS_ULPI_NXT
-            $peripherals.PC0.reborrow(),   // USB_OTG_HS_ULPI_STP
-            $peripherals.PA3.reborrow(),   // USB_OTG_HS_ULPI_D0
-            $peripherals.PB0.reborrow(),   // USB_OTG_HS_ULPI_D1
-            $peripherals.PB1.reborrow(),   // USB_OTG_HS_ULPI_D2
-            $peripherals.PB10.reborrow(),  // USB_OTG_HS_ULPI_D3
-            $peripherals.PB11.reborrow(),  // USB_OTG_HS_ULPI_D4
-            $peripherals.PB12.reborrow(),  // USB_OTG_HS_ULPI_D5
-            $peripherals.PB13.reborrow(),  // USB_OTG_HS_ULPI_D6
-            $peripherals.PB5.reborrow(),   // USB_OTG_HS_ULPI_D7
+            $peripherals.PA5.reborrow(),  // USB_OTG_HS_ULPI_CK
+            $peripherals.PC2.reborrow(),  // USB_OTG_HS_ULPI_DIR
+            $peripherals.PC3.reborrow(),  // USB_OTG_HS_ULPI_NXT
+            $peripherals.PC0.reborrow(),  // USB_OTG_HS_ULPI_STP
+            $peripherals.PA3.reborrow(),  // USB_OTG_HS_ULPI_D0
+            $peripherals.PB0.reborrow(),  // USB_OTG_HS_ULPI_D1
+            $peripherals.PB1.reborrow(),  // USB_OTG_HS_ULPI_D2
+            $peripherals.PB10.reborrow(), // USB_OTG_HS_ULPI_D3
+            $peripherals.PB11.reborrow(), // USB_OTG_HS_ULPI_D4
+            $peripherals.PB12.reborrow(), // USB_OTG_HS_ULPI_D5
+            $peripherals.PB13.reborrow(), // USB_OTG_HS_ULPI_D6
+            $peripherals.PB5.reborrow(),  // USB_OTG_HS_ULPI_D7
         )
     }};
 }
@@ -95,24 +95,38 @@ impl<'d> UsbSystem<'d> {
     pub fn new(
         peripherals: (
             Peri<'d, USB_OTG_HS>,
-            Peri<'d, PA5>,   // USB_OTG_HS_ULPI_CK
-            Peri<'d, PC2>,   // USB_OTG_HS_ULPI_DIR
-            Peri<'d, PC3>,   // USB_OTG_HS_ULPI_NXT
-            Peri<'d, PC0>,   // USB_OTG_HS_ULPI_STP
-            Peri<'d, PA3>,   // USB_OTG_HS_ULPI_D0
-            Peri<'d, PB0>,   // USB_OTG_HS_ULPI_D1
-            Peri<'d, PB1>,   // USB_OTG_HS_ULPI_D2
-            Peri<'d, PB10>,  // USB_OTG_HS_ULPI_D3
-            Peri<'d, PB11>,  // USB_OTG_HS_ULPI_D4
-            Peri<'d, PB12>,  // USB_OTG_HS_ULPI_D5
-            Peri<'d, PB13>,  // USB_OTG_HS_ULPI_D6
-            Peri<'d, PB5>,   // USB_OTG_HS_ULPI_D7
+            Peri<'d, PA5>,  // USB_OTG_HS_ULPI_CK
+            Peri<'d, PC2>,  // USB_OTG_HS_ULPI_DIR
+            Peri<'d, PC3>,  // USB_OTG_HS_ULPI_NXT
+            Peri<'d, PC0>,  // USB_OTG_HS_ULPI_STP
+            Peri<'d, PA3>,  // USB_OTG_HS_ULPI_D0
+            Peri<'d, PB0>,  // USB_OTG_HS_ULPI_D1
+            Peri<'d, PB1>,  // USB_OTG_HS_ULPI_D2
+            Peri<'d, PB10>, // USB_OTG_HS_ULPI_D3
+            Peri<'d, PB11>, // USB_OTG_HS_ULPI_D4
+            Peri<'d, PB12>, // USB_OTG_HS_ULPI_D5
+            Peri<'d, PB13>, // USB_OTG_HS_ULPI_D6
+            Peri<'d, PB5>,  // USB_OTG_HS_ULPI_D7
         ),
         usb_buffers: &'d mut UsbBuffers,
     ) -> Self {
         info!("Initializing USB system...");
 
-        let (usb_otg_hs, ulpi_clk, ulpi_dir, ulpi_nxt, ulpi_stp, ulpi_d0, ulpi_d1, ulpi_d2, ulpi_d3, ulpi_d4, ulpi_d5, ulpi_d6, ulpi_d7) = peripherals;
+        let (
+            usb_otg_hs,
+            ulpi_clk,
+            ulpi_dir,
+            ulpi_nxt,
+            ulpi_stp,
+            ulpi_d0,
+            ulpi_d1,
+            ulpi_d2,
+            ulpi_d3,
+            ulpi_d4,
+            ulpi_d5,
+            ulpi_d6,
+            ulpi_d7,
+        ) = peripherals;
 
         // Configure USB device descriptor
         let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);


### PR DESCRIPTION
This commit introduces the ICM-20689 IMU driver, including SPI configuration and DMA support for high-speed data transfer.

The main application is updated to initialize and run the IMU alongside the USB system and echo application, allowing for concurrent data acquisition.

Additionally, the USB system is refactored to improve peripheral management and buffer handling.